### PR TITLE
shorten some names for allow for longer project names

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.2.6"
+appVersion: "1.2.7"
 description: A Helm chart for Kubernetes
 name: alb-ingress-default
-version: 1.2.6
+version: 1.2.7

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -12,7 +12,7 @@ metadata:
     chart: {{ include "alb-ingress-default.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    appSelector: deployment-{{ $appName }}
+    appSelector: dep-{{ $appName }}
     albIngressName: "default"
 spec:
   replicas: 1
@@ -20,13 +20,13 @@ spec:
     matchLabels:
       app: {{ include "alb-ingress-default.name" . }}
       release: {{ .Release.Name }}
-      appSelector: deployment-{{ $appName }}
+      appSelector: dep-{{ $appName }}
   template:
     metadata:
       labels:
         app: {{ include "alb-ingress-default.name" . }}
         release: {{ .Release.Name }}
-        appSelector: deployment-{{ $appName }}
+        appSelector: dep-{{ $appName }}
         logzio: {{ .Values.logzio }}
         albIngressName: "default"
       {{- if .Values.deployment.name }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -31,5 +31,5 @@ spec:
         paths:
           - path: {{ .Values.ingress.path }}
             backend:
-              serviceName: {{ $appName }}-nodeport
+              serviceName: {{ $appName }}-np
               servicePort: {{ $port }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -5,7 +5,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $appName }}-nodeport
+  name: {{ $appName }}-np
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "alb-ingress-default.name" . }}
@@ -21,5 +21,5 @@ spec:
       name: port
       targetPort: {{ $port }}
   selector:
-    appSelector: deployment-{{ $appName }}
+    appSelector: dep-{{ $appName }}
 {{- end }}


### PR DESCRIPTION
We're shortening `appSelector` to `dep-{{ $appName }}` and `serviceName`   to `{{ $appName }}-np` to allow for slightly longer name combinations. The max length allowed for DNS reasons is 63.