### PR TITLE
`apiVersion: apps/v1beta2` to `apiVersion: apps/v1` for the deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.2.8"
+appVersion: "1.2.9"
 description: A Helm chart for Kubernetes
 name: alb-ingress-default
-version: 1.2.8
+version: 1.2.9

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -2,7 +2,7 @@
 {{- $fallbackName := printf "%s-%s-shared-%s" .Release.Namespace .Values.ingress.type .Values.ingress.cluster -}}
 {{- $appName := .Values.overrideName | default $fallbackName -}}
 {{- $port := .Values.deployment.port | default 8080 }}
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ $appName }}


### PR DESCRIPTION
This is to fix the following with the upgrade to v1.16 when `helm` tries to rehydrate the `whiteboard` releases:

```
Error: UPGRADE FAILED: failed decoding reader into objects: unable to recognize "": no matches for kind "Deployment" in version "apps/v1beta2"
```