### PR TITLE
Support NLBs that come w/ k8s 1.15+ and AWS Load Balancer Controller 2+

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.service.type "LoadBalancer" }}
 {{- $fallbackName := printf "%s-%s-shared-%s" .Release.Namespace .Values.ingress.type .Values.ingress.cluster -}}
 {{- $appName := .Values.overrideName | default $fallbackName -}}
 {{- $port := .Values.deployment.port | default 8080 -}}
@@ -33,3 +34,4 @@ spec:
             backend:
               serviceName: {{ $appName }}-np
               servicePort: {{ $port }}
+{{- end }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -7,6 +7,10 @@ kind: Service
 metadata:
   name: {{ $appName }}-np
   namespace: {{ .Release.Namespace }}
+  {{- if eq .Values.service.type "LoadBalancer" }}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: nlb
+  {{- end }}
   labels:
     app: {{ include "alb-ingress-default.name" . }}
     chart: {{ include "alb-ingress-default.chart" . }}


### PR DESCRIPTION
Need to test some more. This seems to work with a Type LoadBalancer, even though our clusters do not meet the requirements for LoadBalancer.

> - _Kubernetes >= 1.15 for ALB_
> - _Kubernetes >= 1.15 for NLB IP using Service type NodePort_
> - _Kubernetes >= 1.20 or EKS >= 1.16 for NLB IP using Service type LoadBalancer_
>
> – from https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller#prerequisites

This was done on the EKS DEV cluster which has the most current AWS Load Balancer Controller installed.

```bash
➜ git clone git@github.com:cnnlabs/cnn-alb-ingress-default.git
➜ cd cnn-alb-ingress-default/
➜ kctx cnn-eks-dev.admin
➜ kubens devops-tools-prod
➜ helm uninstall devops-tools-prod-public
➜ helm upgrade --install devops-tools-prod-public . \
    --set deployment.create=true \
    --set service.type=LoadBalancer \
    --set ingress.type=public \
    --set ingress.cluster=eks-dev \
    --set ingress.domain=cnnio.net \
    --set ingress.securityGroup=cnn-eks-dev-public \
    --set ingress.bucketName=alb-logs-cnn-eks-dev \
    --set ingress.certArn=...

➜ aws elbv2 describe-load-balancers --query 'LoadBalancers[?Type==`network` && VpcId==`vpc-0e5c84d76c91669b6`].{DNSName: DNSName, Type: Type}' --output table
----------------------------------------------------------------------------------------------
|                                    DescribeLoadBalancers                                   |
+---------------------------------------------------------------------------------+----------+
|                                     DNSName                                     |  Type    |
+---------------------------------------------------------------------------------+----------+
|  a735989fb43a24279b516224869ec970-d8c2b2fb2c3becc7.elb.us-east-1.amazonaws.com  |  network |
+---------------------------------------------------------------------------------+----------+
```

This also creates an ALB as well. The last one in the list.

```bash
➜ aws elbv2 describe-load-balancers --query 'LoadBalancers[?Type==`application` && VpcId==`vpc-0e5c84d76c91669b6`].{DNSName: DNSName, Type: Type}' --output table
-------------------------------------------------------------------------------------------
|                                  DescribeLoadBalancers                                  |
+--------------------------------------------------------------------------+--------------+
|                                  DNSName                                 |    Type      |
+--------------------------------------------------------------------------+--------------+
|  22e80197-prometheus-promet-ecb5-82038553.us-east-1.elb.amazonaws.com    |  application |
|  22e80197-devopstoolsnonpro-47cf-103162193.us-east-1.elb.amazonaws.com   |  application |
|  22e80197-devopstoolsprod-d-f867-604553773.us-east-1.elb.amazonaws.com   |  application |
|  22e80197-devopstoolsprod-d-c1fb-536874091.us-east-1.elb.amazonaws.com   |  application |
|  22e80197-devopstoolsnonpro-3f91-1931334671.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-ingressnginx-ingr-8872-1385041034.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-grahamtestproject-7c5a-1426943529.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-grahamtestproject-85aa-218344221.us-east-1.elb.amazonaws.com   |  application |
|  22e80197-grahamtestproject-27d9-1676969828.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-grahamtestproject-ab72-963677215.us-east-1.elb.amazonaws.com   |  application |
|  22e80197-whiteboardnonprod-c9eb-1500575992.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-whiteboardnonprod-d13d-1169611730.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-whiteboardprod-wh-df5d-2023893385.us-east-1.elb.amazonaws.com  |  application |
|  22e80197-whiteboardprod-wh-fd18-2061168469.us-east-1.elb.amazonaws.com  |  application |
|  k8s-devopsto-devopsto-0db11e47e0-306281817.us-east-1.elb.amazonaws.com  |  application |  ## <-- THIS ONE
+--------------------------------------------------------------------------+--------------+
```

This is the ALB that the Ingress is tied to.

```bash
➜ kc get ing
NAME                                      HOSTS                                               ADDRESS                                                                  PORTS   AGE
devops-tools-prod-public-shared-eks-dev   devops-tools-prod-public-shared-eks-dev.cnnio.net   k8s-devopsto-devopsto-0db11e47e0-306281817.us-east-1.elb.amazonaws.com   80      44m

➜ curl -sS devops-tools-prod-public-shared-eks-dev.cnnio.net
devops-tools-prod-public-shared-eks-dev-6c75478bfb-5g5hk%
```
